### PR TITLE
Docs update, prep for radio, from tbl-ftag(bzr#96)

### DIFF
--- a/pico_instructions.md
+++ b/pico_instructions.md
@@ -1,5 +1,16 @@
 # Running the demos on pico-MicroPython
 
+For these tests, you might have multiple links configured. If this is the case,
+when you import the ftag module, you might get this message, in which case,
+choose the U option for the UART link (as radio.py isn't released yet).
+
+```python
+>>> import ftag
+OPTION=1
+[U]ART or [R]adio [UR]? U
+>>> 
+```
+
 ## loading code to both Picos
 
 Install the rshell utility
@@ -35,7 +46,10 @@ ftag.loopback()
 Connect PicoA(sender) Pin1 to PicoB(receiver) Pin2
 Connect PicoA(sender) GND-Pin38 to PicoB(receiver) GND-Pin38
 
-NOTE: start the receiver, before you start the sender!
+NOTE: best to start the receiver, before you start the sender.
+However, the protocol is resilient, and if you get to the END record
+before all blocks are received, the receiver will prompt you to re-run
+send() to get the remaining blocks.
 
 ```python
 # use Thonny, or putty, or on mac/linux, use screen command

--- a/src/dtcli.py
+++ b/src/dtcli.py
@@ -60,7 +60,7 @@ def run_receive(filename:str, progress:bool=False):
     #NOTE: progress flag not supported currently
     receiver = ftag.receive_file_task(filename, link=link_manager)
     receiver.run()
-    ftag.print_stats("rx:", receiver)
+    ftag.print_stats("rx", receiver)
 
 #----- BIN2HEX -----------------------------------------------------------------
 

--- a/src/ftag_host.py
+++ b/src/ftag_host.py
@@ -51,16 +51,17 @@ def receive_file_task(filename:str, link=None) -> dttk.Receiver: # or exception
 # NOISE_SPEC = {"prob": 1, "byte": (1,10)}
 # noise_gen = dttk.NoiseGenerator(NOISE_SPEC).send
 # def noisy_receive(info:dict or None=None) -> bytes or None:
-#     return noise_gen(radio.recvinto(buf, info))
+#     return noise_gen(packetised_link.recvinto(buf, info))
 # receiver = dttk.FileReceiver(noisy_receive, filename, progress_fn=rx_progress)
 # return receiver  # has-a tick() and run()
 
-def print_stats(name:str, task) -> None:
+
+def print_stats(name:str or None=None, task=None) -> None:
     """Host-specific print_stats for sender or receiver"""
-    platdeps.message("stats for:%s" % name)
-    platdeps.message("  link:     %s" % str(dttk.link_stats))
-    platdeps.message("  pkt:      %s" % str(dttk.packetiser_stats))
-    platdeps.message("  transfer: %s" % task.get_stats())
+    if name is not None:                 platdeps.message("STATS:%s" % name)
+    if dttk.link_stats.has_data():       platdeps.message("link: %s" % str(dttk.link_stats))
+    if dttk.packetiser_stats.has_data(): platdeps.message("pkt:  %s" % str(dttk.packetiser_stats))
+    if task is not None:                 platdeps.message("xfer: %s" % task.get_stats())
 
 #END: ftag_host.py
 

--- a/src/load_pico
+++ b/src/load_pico
@@ -23,6 +23,8 @@ cp ftag_pico.py /pyboard
 cp perf.py /pyboard
 cp tasking.py /pyboard
 cp myboard.py /pyboard
+cp radio.py /pyboard
+cp test_radio.py /pyboard
 cp test35k.jpg /pyboard
 cp testdata.txt /pyboard
 rm /pyboard/received.jpg

--- a/src/myboard.py
+++ b/src/myboard.py
@@ -1,0 +1,62 @@
+# myboard.py  16/02/2023  D.J.Whale - board defs for pins, etc
+
+import platdeps
+
+if platdeps.PLATFORM == platdeps.MPY:
+    from machine import Pin
+
+    # General pins
+    OPTION_GPN = 16
+    option_pin = Pin(OPTION_GPN, Pin.IN)
+    OPTION     = option_pin()  # read the option pin once
+    # In test_radio we use OPTION=0 for receive(), OPTION=1 for send()
+    # For ftag Uart tests, we show option, but don't do anything with it
+
+    RX_LED_GPN = 27
+    rx_led_pin = Pin(RX_LED_GPN, Pin.OUT)
+
+    class UartCfg:
+        # UartLink
+        BAUD_RATE  = 115_200
+        PORT       = 1
+        TX_GPN     = 20  # LED1 on picosat
+        RX_GPN     = 21  # LED2 on picosat
+        BLOCK_SIZE = 50
+        # tx_pin
+        # rx_pin
+
+    class RadioCfg:
+        # SPI_MODES: 0=CPOL0 CPHA0, 1=CPOL0 CPHA1 2=CPOL1 CPHA0, 3=CPOL1 CPHA1
+        SPEED_HZ    = 1_000_000  # RFM69 datasheet says 10MHz max allowed
+        SPI_N       = 0
+        GPN_G0      = 0  # DIO0 INT pin
+        GPN_CS      = 1
+        GPN_SCK     = 2
+        GPN_MOSI    = 3
+        GPN_MISO    = 4
+        GPN_RES     = 6  # must be low in normal operation (floats high)
+        GPN_EN      = 7  # must be high to enable regulator (floats high)
+        GPN_TX_LED = 26
+        GPN_RX_LED = 27
+        # Don't make Pins outputs here, do in driver TODO: or set initial states here
+        #g0_pin     = Pin(GPN_G0)     ##, Pin.IN)
+        #cs_pin     = Pin(GPN_CS)     ##, Pin.OUT)
+        #sck_pin    = Pin(GPN_SCK)    ##, Pin.OUT)
+        #mosi_pin   = Pin(GPN_MOSI)   ##, Pin.OUT)
+        #miso_pin   = Pin(GPN_MISO)   ##, Pin.IN)
+        #res_pin    = Pin(GPN_RES)    ##, Pin.OUT)
+        #en_pin     = Pin(GPN_EN)     ##, Pin.OUT)
+        #tx_led_pin = Pin(GPN_TX_LED) ##, Pin.OUT)
+        #rx_led_pin = Pin(GPN_RX_LED) ##, Pin.OUT)
+
+        #TODO: parameters we might want to fiddle with later
+        #TX_POWER       = 0dBm
+        #BAUD_RATE      = 250_000
+        #DEVIATION_FREQ = 250_000
+        #CARRIER_FREQ   = 433_920_000
+        #DUTY_CYCLE     = 100
+
+else:
+    pass # no defs for CPYTHON
+
+#END: myboard.py

--- a/src/platdeps.py
+++ b/src/platdeps.py
@@ -1,0 +1,72 @@
+# platdeps.py  16/03/2023  D.J.Whale - platform dependencies
+
+# detect platform
+MPY     = "mpy"
+CPYTHON = "cpy"
+
+try:
+    import utime  # MicroPython
+    PLATFORM = MPY
+
+except ImportError:
+    # we are on Host
+    PLATFORM = CPYTHON
+
+#----- CYPYTHON ----------------------------------------------------------------
+
+if PLATFORM == CPYTHON:
+    # scaffolding
+    class micropython:
+        # no viper, use this as a null decorator
+        @staticmethod
+        def viper(fn:callable) -> callable: return fn
+    ptr8 = bytes
+    ptr16 = bytes
+
+    import time
+    import os
+    import hashlib
+    import sys
+
+    time_time        = time.time  # seconds&ms, float
+    time_perf_time   = time.time  # seconds&ms, float
+    time_ms          = lambda: int(time.time() * 1000)  # milliseconds
+    time_sleep_ms    = lambda ms: time.sleep(ms / 1000.0)
+
+    os_path_basename = os.path.basename
+    os_rename        = os.rename
+    os_unlink        = os.unlink
+    filesize         = lambda filename: os.stat(filename).st_size
+    hashlib_sha256   = hashlib.sha256
+
+    message          = lambda msg: sys.stderr.write(msg + '\n')
+    decode_to_str    = lambda b: b.decode(errors='ignore')
+
+#----- MICRO PYTHON ------------------------------------------------------------
+elif PLATFORM == MPY:
+    import utime
+    import os
+    import uhashlib
+    import micropython
+
+    time_time        = utime.time      # seconds, int
+    time_perf_time   = utime.ticks_us  # us, int
+    time_ms          = utime.ticks_ms  # ms, int
+    time_sleep_ms    = utime.sleep_ms  # ms, int
+    os_path_basename = lambda p: p     #NOTE: TEMPORARY fix
+    os_rename        = os.rename
+    os_unlink        = os.remove
+    filesize         = lambda filename: os.stat(filename)[6]
+    hashlib_sha256   = uhashlib.sha256
+    message          = print
+
+    def decode_to_str(b:bytes) -> str:
+        # There is no "errors='ignore'" on Pico
+        try:
+            return b.decode()
+        # Pico throws UnicodeError, not UnicodeDecodeError
+        except UnicodeError:
+            print("unicode decode error")
+            return "<UnicodeError>"  # this is the best we can do
+
+#END: platdeps.py

--- a/src/tasking.py
+++ b/src/tasking.py
@@ -38,7 +38,7 @@ def run_all(tasks:list, trace:callable or None=None) -> None:
             i += 1
 
 def test():
-    class Task():
+    class Task:
         def __init__(self, name:str, v:int):
             self._name = name
             self._v = v

--- a/src/test_bitset.py
+++ b/src/test_bitset.py
@@ -1,0 +1,28 @@
+# test_bitset.py  21/02/2023  D.J.Whale
+
+import random
+from dttk import BitSet
+
+def test_random():
+    SIZE = round(35000/50)
+    ##SIZE = 1000
+    b = BitSet(SIZE)
+
+    while not b.is_complete():
+        i = random.randint(0,SIZE-1)
+        b[i] = 1
+        print(str(b))
+    print(repr(b))
+
+def test_deterministic():
+    SIZE = round(35000/50)
+    b = BitSet(SIZE)
+
+    print("-", str(b))
+    for i in range(SIZE):  # set the first 11 bits
+        b[i] = 1
+        print(i, str(b))
+
+if __name__ == "__main__":
+    test_random()
+    test_deterministic()

--- a/src/test_dttk.py
+++ b/src/test_dttk.py
@@ -20,7 +20,7 @@ class ByteStreamGenerator(dttk.Link):
         self._data = data
         self._idx = 0
 
-    def recvinto(self, buf:dttk.Buffer, info:dict or None=None, wait:bool=False) -> int or None:
+    def recvinto(self, buf:dttk.Buffer, info:dict or None=None, wait:int=0) -> int or None:
         """Copy as much data in as we have and buf will accept"""
         _ = info  # argused
         remaining = len(self._data) - self._idx
@@ -498,7 +498,7 @@ class DummyRadio:
         self._rx_idx += 1
         return nb
 
-    def recvinto(self, buf:dttk.Buffer, info:dict or None=None, wait:bool=False) -> int or None:
+    def recvinto(self, buf:dttk.Buffer, info:dict or None=None, wait:int=0) -> int or None:
         # blocking receive, assumes we always transmit first to the queue
         nb = self._get_next_nb()
         ##print("recvinto: next nb:%s" % nb)
@@ -528,8 +528,8 @@ class PacketisedDummyRadio(dttk.Link):
         self.send = self._send_packetiser.send
         ##self.recvinto = self._packetiser.recvinto
 
-    def recvinto(self, buf:dttk.Buffer, info:dict or None=None, wait:bool=False) -> int or None:
-        nb = self._recv_packetiser.recvinto(buf, info, wait=True)
+    def recvinto(self, buf:dttk.Buffer, info:dict or None=None, wait:int=0) -> int or None:
+        nb = self._recv_packetiser.recvinto(buf, info, wait=1)  #TODO: now in ms, manifest constant?
         ##print("Packetiser.recvinto:%s %s" % (nb, dttk.hexstr(buf[:])))
         assert nb is not None, "<<recvinto HERE"  #temporary hard stop
         return nb
@@ -678,9 +678,10 @@ class InteractiveLink(dttk.Link):
         print("data:%s" % str(data))
 
     @staticmethod
-    def recvinto(user_buf:dttk.Buffer, info:dict or None=None) -> int or None:
+    def recvinto(user_buf:dttk.Buffer, info:dict or None=None, wait:int=0) -> int or None:
         assert isinstance(user_buf, dttk.Buffer), "want:Buffer, got:%s" % str(type(user_buf))
         _ = info  # argused
+        _ = wait  # argused
         l = user_buf.get_max()
         try:
             d = input("data(%d)> " % l)

--- a/src/test_radio_spi.py
+++ b/src/test_radio_spi.py
@@ -1,0 +1,67 @@
+# test_radio_spi.py  11/02/2023  D.J.Whale - test RFM69 radio on SPI0
+
+from machine import SPI, Pin
+from utime import sleep_ms, sleep_us
+
+SPEED_HZ = 400_000
+SPI_N = 0
+
+GP_G0 = 0  # input
+GP_CS = 1  # output
+GP_SCK = 2  # output
+GP_MOSI = 3  # output
+GP_MISO = 4  # input
+GP_RES = 6  # output (low for run)
+GP_EN = 7  # output (enable power supply or leave disconnected for on)
+
+spi = SPI(SPI_N, baudrate=SPEED_HZ, polarity=0, phase=0, bits=8,
+          sck=Pin(GP_SCK), mosi=Pin(GP_MOSI), miso=Pin(GP_MISO))
+spi_cs = Pin(GP_CS, Pin.OUT)
+spi_cs.high()  # deselected
+res = Pin(GP_RES, Pin.OUT)
+res.low()
+
+def test_pin(name: str, pin_no: int):
+    print("test_pin:%s %d" % (name, pin_no))
+    p = Pin(pin_no, Pin.OUT)
+    for _ in range(8):
+        p.high()
+        sleep_ms(250)
+        p.low()
+        sleep_ms(250)
+
+def reset():
+    print("resetting")
+    res.high()
+    sleep_ms(150)
+    res.low()
+    sleep_us(100)
+    print("resetting done")
+
+def xfer(data: bytes):
+    print("tx")
+    spi_cs.low()  # select
+    res = bytearray(len(data))
+    spi.write_readinto(data, res)
+    spi_cs.high()  # deselect
+    print("tx done")
+    return res
+
+def readreg(addr: int) -> int:
+    return xfer(bytearray((addr, 0)))[1]
+
+def test():
+    R_VERSION = 0x10
+    EXPECTED = 0x24
+    reset()
+    actual = readreg(R_VERSION)
+    if EXPECTED != actual:
+        print("FAIL: expected:%02X got:%02X" % (EXPECTED, actual))
+    else:
+        print("PASS: version=%02X" % actual)
+
+print("test_radio: use test()")
+
+
+
+


### PR DESCRIPTION
bzr#86..bzr#96 diffs:
Updated instructions
radio optional, if module not there, fail soft
Improved print_stats format
print_stats also works with no parameters, so can call interactively on stop Verified the jpg received, it is intact
better progress monitoring - shows bitset of received blocks - allows restart doesn't terminate transfer unless metadata changes. Now display blockmap status when END appears
New bitset added into ftag, str() now shows 80 char status of fullness Fixed remainder bit issue
Fixed the phantom bit issue
Fixed bitset off by one error
created a tester for new bitset
Designed code for new BitSet.__str__
tested with uart, new verifying chk state still works add the CHK_COMPLETE state, independent of VERIFYING split verification from end detect, for resume
radio now in ftag_pico
Placeholders added for pin redirects
Fixed the off-by-one length on send
display received data in radio_test as hex
use '?' for out of range ASCII chars.
Improved received trace
new test_radio API integrated
Recoded test_radio to use Buffer
Introduced send() and recvinto() API in radio.py with Buffer dependency Tested new receive wait API with timeout int flag
Introduced recvinto(wait) polling in ftag_pico.UartLink New wait:int API deployed
changed all wait:bool=False into wait:int=0 for all recvinto() fns pass in '1' instead of True,
new wait:int API design, for recvinto
designed architecture: recvinto(wait)
ftag_pico now has a get_phy() question for Uart or Radio. Removed radio names from uart pipeline in ftag_pico radio now uses myboard GPN numbers
removed RSSIRDY and return None
introduced platdeps in radio.py for sleep_ms and ticks_ms(now_ms) added a trace:bool=False flag to the radio
removed MOCKING and host code from radio
added a counter so we don't get scroll effects on trace test_radio refactored to use myboard and RadioISM import preparation for moving this into ftag_pico
move radio.py and test_radio.py into the ftag folder Power calcs documented
Captured txpower calcs, in case any questions ever asked about them. Configured the radio for 0dBm mode (PA1 only) which allows any duty cycle/bw Pushed the baud rate and FDEV up to 300kbps - works well at 250kbps Frequency dev calculator in place - still works at 30kHz frequency deviation word calculator
bw values increased
Changed data shaping to whitening
Changed packet preamble, now longer to allow better RSSI Have reduced to minimum tx power for this PA setting Now will display RSSI against each rx packet trace Wrote code for RSSI measure
Captured some RSSI reg defaults and data
sorted regs into regions that align with data sheet ordering added default values in comments for all radio regs use a tuple for the radio config
time delays tweaked a bit
Fixed a hard coded 32 byte limit, now 66
Moved further work from README.md to github issues created a board definition file
mapped UART pins etc into that file
OPTION displayed when ftag is imported
platdeps introduced and working