### PR TITLE
sdcard support and additional hardware testers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ please read [host_instructions.md](./host_instructions.md)
 For use on a Raspberry Pi Pico running MicroPython,
 please read [pico_instructions.md](./pico_instructions.md)
 
+For the ```sdtool``` SDCard tester,
+please read [sdtool_instructions.md](./sdtool_instructions.md)
 
 ## What is it for?
 

--- a/sdtool_instructions.md
+++ b/sdtool_instructions.md
@@ -1,0 +1,204 @@
+# SDTOOL - SD Card experimeter tool
+
+This is a simple tool that allows you to read and write SDCards at the raw
+block level. You can also access various setup info from the card, and walk
+through partitions to get at the data blocks. 
+
+It is designed to run unmodified on the Raspberry Pi Pico using the default
+MicroPython build for the Pico. It could be adapted for use on other platforms
+quite easily.
+
+To use it, you need the following two files flashed onto your Raspberry Pi Pico:
+
+```
+sdcard.py
+sdtool.py
+```
+
+## Wiring up your SDCard
+
+Tests were performed using the 
+[Adafruit Micro SD SPI or SDIO 3V Breakout Board](https://www.adafruit.com/product/4682)
+
+In the default setup we use this pinning, but you can change the constants
+at the top of ```sdcard.py``` if you need a different setup. The CD
+(card detect) is not used in this tester.
+
+```python
+SPI_N    = 1
+GP_SCK   = 10  # output
+GP_MOSI  = 11  # output
+GP_MISO  = 12  # input
+GP_CS    = 13  # output
+```
+
+## Running SDTOOL
+
+Just import the module and it runs the tester.
+
+```python
+import sdtool
+```
+
+A small menu is provided:
+
+```
+sdtool - SD card experimenter tool
+c:connect i:info m:dumpmbr p:dumppart b:dumpblk W:writetst E:eject? 
+```
+
+First connect to the card with the 'c' command. If no card is fitted or
+if there is a wiring error, this won't work (and no other commands will work).
+
+Once connected, use the other commands as follows:
+
+## i - Info command
+
+Shows the CID and CSD records from the card.
+```
+CID: 1B 53 4D 30 30 30 30 30 10 40 87 5E 53 00 DB 5D .SM00000.@.^S..]
+CSD: 40 0E 00 32 5B 59 00 00 3A CD 7F 80 0A 40 00 97
+```
+
+The [SD-card Physical layer specification (simplified)](https://www.sdcard.org/downloads/pls/) 
+from sdcard.org details the format of these two records
+
+## m - Dump Master Boot Record
+
+The master boot record (MBR) holds the primary partition table.
+It ends in 55AA if the record is valid. Each primary partition record is
+16 bytes in length.
+
+```
+000: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+090: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0A0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0B0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0C0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0D0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0E0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0F0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+more?
+100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+110: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+120: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+130: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+140: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+150: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+160: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+170: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+190: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1A0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1B0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 FE ................
+1C0: FF FF 0B FE FF FF 02 00 00 00 FE 37 EB 00 00 00 ...........7....
+1D0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1E0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1F0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 55 AA ..............U.
+```
+
+## p - Dump the partition table from the MBR
+
+There are 4 records in the MBR partition table. Decode details can be found on the 
+[Master Boot Record Wikipedia page](https://en.wikipedia.org/wiki/Master_boot_record)
+
+Type fields are enumerated
+[here](https://www.win.tue.nl/~aeb/partitions/partition_types-1.html)
+
+```
+p0: 00 FE FF FF 0B FE FF FF 02 00 00 00 FE 37 EB 00
+p1: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+p2: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+p3: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+
+f:00 first:FFFFFE ty:0B last:FFFFFE LBA:00000002 ns:00EB37FE
+
+0: Region(r_start=2, r_size=15415294) (7892630528 bytes)
+1: unused
+2: unused
+3: unused
+```
+
+## b - dump a block in a partition
+
+The first parameter is the MBR partition index [0..4] next parameter is block_no
+within that partition. Note, in a FAT partition, block 0 of the partition
+has all the useful information in it (and ends in 55AA if it is valid)
+
+```
+c:connect i:info m:dumpmbr p:dumppart b:dumpblk W:writetst E:eject? b 0 0
+000: EB 58 90 42 53 44 20 20 34 2E 34 00 02 08 20 00 .X.BSD  4.4... .
+010: 02 00 00 00 00 F8 00 00 20 00 FF 00 02 00 00 00 ........ .......
+020: FE 37 EB 00 B1 3A 00 00 00 00 00 00 02 00 00 00 .7...:..........
+030: 01 00 06 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+040: 80 00 29 E8 13 AA FD 57 48 41 4C 45 59 5F 53 44 ..)....WHALEY_SD
+050: 20 20 46 41 54 33 32 20 20 20 FA 31 C0 8E D0 BC   FAT32   .1....
+060: 00 7C FB 8E D8 E8 00 00 5E 83 C6 19 BB 07 00 FC .|......^.......
+070: AC 84 C0 74 06 B4 0E CD 10 EB F5 30 E4 CD 16 CD ...t.......0....
+080: 19 0D 0A 4E 6F 6E 2D 73 79 73 74 65 6D 20 64 69 ...Non-system di
+090: 73 6B 0D 0A 50 72 65 73 73 20 61 6E 79 20 6B 65 sk..Press any ke
+0A0: 79 20 74 6F 20 72 65 62 6F 6F 74 0D 0A 00 00 00 y to reboot.....
+0B0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0C0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0D0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0E0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+0F0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+more?
+100: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+110: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+120: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+130: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+140: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+150: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+160: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+170: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+190: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1A0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1B0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1C0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1D0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1E0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ................
+1F0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 55 AA ..............U.
+```
+
+## W - perform a repeated write test (for write speed testing)
+
+This test writes to physical block 4, 16 times, with random data.
+It restores the block to its previous values when the test completes.
+
+This is intended to be used to get a measure on how long it takes a card
+to commit data to the flash. 
+
+Note that you will get a range of results from your card. On my card,
+the first write sometimes takes up to 100ms to complete, but then the next
+few hundred writes take about 8ms. SDCards internally do wear levelling,
+so it is possible that this discrepancy in write times is the wear levelling
+algorithm deciding whether to map the data to a new block (fast) or erase
+and use an existing block (much slower).
+
+Also, different speed-class cards will perform differently.
+
+If you decode the CSD record returned from the info command, you can often
+identify the advertised response and write times of a particular card.
+
+```
+write-test with physical block_no:4
+count: 16 avg: 10,829 us
+min time: 7,549 us
+max time: 35,926 us
+```
+
+## E - eject card 
+
+This just invalidates any state that the sdtool has cached about a card.
+Use the 'c' command again to connect to a card.
+

--- a/src/dttk.py
+++ b/src/dttk.py
@@ -1851,13 +1851,14 @@ class FileReceiver(Receiver):
     """Receive something we know to be a disk file"""
     #NOTE: If you want to receive sensor data, use a Receiver() directly
 
+    FILENAME_BASE = "received"  # adds extn on based on transmitted metadata
+
     def __init__(self, link_manager:LinkManager, filename:str or None, progress_fn:callable or None=None,
                  cached:bool=False):
         #NOTE: cached for Raspberry Pi Pico local filesystem
         #NOTE: uncached for sdcard or host file system
 
         # No metadata received yet
-        self._local_filename = filename # might be None
         self._nblocks        = None
         self._blocksize      = None
         self._lastblock      = None
@@ -1908,6 +1909,7 @@ class FileReceiver(Receiver):
         filename_raw = bytes(data[5+32:-1])  # skip the ZTERM
         filename     = platdeps.decode_to_str(filename_raw)
         filename     = platdeps.os_path_basename(filename)  # no directories allowed
+        _, ext       = platdeps.os_path_splitext(filename)
 
         if self._nblocks is None:
             ##platdeps.message("capturing metadata for file")
@@ -1918,6 +1920,8 @@ class FileReceiver(Receiver):
             self._lastblock        = lastblock
             self._sha256           = sha256
             self._remote_filename  = filename
+            self._local_filename   = self.FILENAME_BASE + ext
+            print("send(%s) -> receive(%s)" % (self._remote_filename, self._local_filename))
 
             # now able to monitor the progress of block transfer
             self.set_block_info(blocksz, nblocks, lastblock)

--- a/src/myboard.py
+++ b/src/myboard.py
@@ -3,24 +3,53 @@
 import platdeps
 
 if platdeps.PLATFORM == platdeps.MPY:
+    # picosat board GPIO numbers (not pin numbers) Raspberry Pi Pico
+    RADIO_G0_GPN    = 0   # {GP0}/TX0/SDA0/DIO/PWM0A
+    RADIO_CS_GPN    = 1   # {GP1}/RX0/SCL0/CS0/PWM0B
+    RADIO_SCK_GPN   = 2   # GP2/SDA1/{SCK0}/PWM1A
+    RADIO_MOSI_GPN  = 3   # GP3/SCL1/DO0/PWM1B
+    RADIO_MISO_GPN  = 4   # GP4/TX1/SDA0/{DI0}/PWM2A
+    CAMERA_CS_GPN   = 5   # {GP5}/RX1/SCL0/CS0/PWM2B
+    RADIO_RES_GPN   = 6   # {GP6}/SDA1/SCK0/PWM3A
+    RADIO_EN_GPN    = 7   # {GP7}/SCL1/DO0/PWM3B
+    CAMERA_SDA_GPN  = 8   # GP8/TX1/{SDA0}/DI1/PWM4A
+    CAMERA_SCL_GPN  = 9   # GP9/RS1/{SCL0}/CS1/PWM4B
+    SDCARD_SCK_GPN  = 10  # GP10/SDA1/{SCK1}/PWM5A
+    SDCARD_MOSI_GPN = 11  # GP11/SCL1/{D01}/PWM5B
+    SDCARD_MISO_GPN = 12  # GP12/TX0/SDA0/{DI1}/PWM6A
+    SDCARD_CS_GPN   = 13  # {GP13}/RX0/SCL0/CS1/PWM6B
+    SPI1_CS_GPN     = 14  # {GP14}/SDA1/SCK1/PWM7A
+    SPI0_CS_GPN     = 15  # {GP15}/PWM7B
+    MISC16_GPN      = 16  # GP16/{TX0}/SDA0/DI0/PWM0A
+    BUTTON_GPN      = 17  # GP17/{RX0}/SCL0/CS0/PWM0B
+    I2C1_SDA_GPN    = 18  # GP18/{SDA1}/SCK0/PWM1A
+    I2C1_SCL_GPN    = 19  # GP19/{SCL1}/DO0/PWM1B
+    LED1_GPN        = 20  # {GP20}/TX1/SDA0/DI0/PWM2A
+    LED2_GPN        = 21  # {GP21}/RX1/SCL0/CS0/PWM2B
+    MISC22_GPN      = 22  # {GP22}/SDA1/SCK0/PWM3A
+    #23..25 not used on Pico
+    MISC26_GPN      = 26  # {GP23}/A0/SDA1/SCK1/PWM5A
+    MISC27_GPN      = 27  # {GP24}/A1/SCL1/DO1/PWM5B
+    MISC28_GPN      = 28  # {GP25}/A2/DI1/PWM6A
+
     from machine import Pin
 
     # General pins
-    OPTION_GPN = 16
+    OPTION_GPN = MISC16_GPN
     option_pin = Pin(OPTION_GPN, Pin.IN)
     OPTION     = option_pin()  # read the option pin once
     # In test_radio we use OPTION=0 for receive(), OPTION=1 for send()
     # For ftag Uart tests, we show option, but don't do anything with it
 
-    RX_LED_GPN = 27
+    RX_LED_GPN = LED2_GPN
     rx_led_pin = Pin(RX_LED_GPN, Pin.OUT)
 
     class UartCfg:
         # UartLink
         BAUD_RATE  = 115_200
         PORT       = 1
-        TX_GPN     = 20  # LED1 on picosat
-        RX_GPN     = 21  # LED2 on picosat
+        TX_GPN     = LED1_GPN  # on our test board only
+        RX_GPN     = LED2_GPN  # on our test board only
         BLOCK_SIZE = 50
         # tx_pin
         # rx_pin
@@ -29,15 +58,15 @@ if platdeps.PLATFORM == platdeps.MPY:
         # SPI_MODES: 0=CPOL0 CPHA0, 1=CPOL0 CPHA1 2=CPOL1 CPHA0, 3=CPOL1 CPHA1
         SPEED_HZ    = 1_000_000  # RFM69 datasheet says 10MHz max allowed
         SPI_N       = 0
-        GPN_G0      = 0  # DIO0 INT pin
-        GPN_CS      = 1
-        GPN_SCK     = 2
-        GPN_MOSI    = 3
-        GPN_MISO    = 4
-        GPN_RES     = 6  # must be low in normal operation (floats high)
-        GPN_EN      = 7  # must be high to enable regulator (floats high)
-        GPN_TX_LED = 26
-        GPN_RX_LED = 27
+        GPN_G0      = RADIO_G0_GPN  # DIO0 INT pin
+        GPN_CS      = RADIO_CS_GPN
+        GPN_SCK     = RADIO_SCK_GPN
+        GPN_MOSI    = RADIO_MOSI_GPN
+        GPN_MISO    = RADIO_MISO_GPN
+        GPN_RES     = RADIO_RES_GPN  # must be low in normal operation (floats high)
+        GPN_EN      = RADIO_EN_GPN  # must be high to enable regulator (floats high)
+        GPN_TX_LED  = LED1_GPN
+        GPN_RX_LED  = LED2_GPN
         # Don't make Pins outputs here, do in driver TODO: or set initial states here
         #g0_pin     = Pin(GPN_G0)     ##, Pin.IN)
         #cs_pin     = Pin(GPN_CS)     ##, Pin.OUT)
@@ -55,6 +84,15 @@ if platdeps.PLATFORM == platdeps.MPY:
         #DEVIATION_FREQ = 250_000
         #CARRIER_FREQ   = 433_920_000
         #DUTY_CYCLE     = 100
+
+    class SDCardCfg:
+        SPEED_SLOW_HZ = 100_000
+        SPEED_FAST_HZ = 1_000_000
+        SPN           = 1
+        CS_GPN        = SDCARD_CS_GPN
+        SCK_GPN       = SDCARD_SCK_GPN
+        MOSI_GPN      = SDCARD_MOSI_GPN
+        MISO_GPN      = SDCARD_MISO_GPN
 
 else:
     pass # no defs for CPYTHON

--- a/src/platdeps.py
+++ b/src/platdeps.py
@@ -34,6 +34,7 @@ if PLATFORM == CPYTHON:
     time_sleep_ms    = lambda ms: time.sleep(ms / 1000.0)
 
     os_path_basename = os.path.basename
+    os_path_splitext = os.path.splitext
     os_rename        = os.rename
     os_unlink        = os.unlink
     filesize         = lambda filename: os.stat(filename).st_size
@@ -49,11 +50,33 @@ elif PLATFORM == MPY:
     import uhashlib
     import micropython
 
+    def basename(path: str) -> str:
+        slash_pos = path.rfind("/")
+        if slash_pos != -1: return path[slash_pos + 1:]
+        return path
+
+    def splitext(path: str) -> tuple:  # (str, str)
+        """Split into path, extn - implements os.path.splitext"""
+        dot_pos = path.rfind(".")
+        if dot_pos == -1: return path, ""  #  no extension
+
+        # found a dot, might be an extension, is it more left than any slash
+        slash_pos = path.rfind("/")
+
+        # if no slash, this dot must be part of the filename part
+        if slash_pos == -1: return path[:dot_pos], path[dot_pos:]
+
+        # there is a slash, is the dot left of the slash
+        if dot_pos < slash_pos: return path, ""  # no extension
+        return path[:dot_pos], path[dot_pos:]  # there is an extension
+
+
     time_time        = utime.time      # seconds, int
     time_perf_time   = utime.ticks_us  # us, int
     time_ms          = utime.ticks_ms  # ms, int
     time_sleep_ms    = utime.sleep_ms  # ms, int
-    os_path_basename = lambda p: p     #NOTE: TEMPORARY fix
+    os_path_basename = basename
+    os_path_splitext = splitext
     os_rename        = os.rename
     os_unlink        = os.remove
     filesize         = lambda filename: os.stat(filename)[6]

--- a/src/sdcard.py
+++ b/src/sdcard.py
@@ -1,0 +1,441 @@
+# sdcard.py  23/02/2023  D.J.Whale - test SD card on SPIn
+
+# class SPI
+#   read(nbytes, write=0x00) -> bytes:
+#   readinto(buf, write=0x00) -> None:
+#   write(buf) -> None:
+#   write_readinto(write_buf, read_buf) -> None:
+
+# for use on Raspberry Pi Pico with standard MicroPython
+from machine import SPI, Pin
+from utime import sleep_ms, sleep_us, ticks_ms, ticks_us
+
+SPEED_SLOW_HZ = 100_000
+SPEED_FAST_HZ = 1_320_000
+
+SPI_N    = 1
+GP_SCK   = 10  # output
+GP_MOSI  = 11  # output
+GP_MISO  = 12  # input
+GP_CS    = 13  # output
+
+# STORED STATE
+cdv        = None # set in init_card to 1 or 512
+cmdbuf     = memoryview(bytearray(16))
+buf1       = cmdbuf[:1]
+start_lba  = 0
+num_lba    = None  # read from CSD record later
+signature  = None  # filled in in init(), to detect card ejects
+
+# init SPI
+spi = SPI(SPI_N, baudrate=SPEED_SLOW_HZ, polarity=0, phase=0, bits=8,
+          sck=Pin(GP_SCK), mosi=Pin(GP_MOSI), miso=Pin(GP_MISO))
+
+# chip select idles high when bus inactive
+spi_cs = Pin(GP_CS, Pin.OUT)
+spi_cs.high()  # deselected
+
+R1_IDLE_STATE         = 1<<0
+R1_ILLEGAL_COMMAND    = 1<<2
+DRT_ACCEPTED          = 0b000_010_1  # data_response_token
+INIT_RETRY_TIMES      = 100  # 100 * 50ms = 5 seconds max
+INIT_RETRY_DELAY_MS   = 50
+TIMEOUT_OF_CMD_US     = 5_000 # 5ms for any single command
+TIMEOUT_WRITE_MS      = 200  # 99,380us measured on bench
+
+# cmd, arg, crc, [final_ff=0], [release=True]
+CMD_INIT                  = (0, 0, 0x95)
+CMD_GET_CARD_VER          = (8, 0x01aa, 0x87, 4)
+CMD_READ_OCR_ND           = (58, 0, 0, 4)
+CMD_SEND_CSD_DATA         = (9, 0, 0, 0, False)
+CMD_SEND_CID_DATA         = (10, 0, 0, 0, False)
+CMD_SET_BLOCKLEN_512      = (16, 512, 0)
+CMDFN_READ_SINGLE_BLOCK   = lambda bn: (17, bn*cdv, 0)
+CMDFN_READ_MULTIPLE_BLOCK = lambda bn: (18, bn*cdv, 0)
+CMDFN_WRITE_BLOCK         = lambda bn: (24, bn*cdv, 0, 0, False)
+TOKEN_DATA = 0xFE
+
+CMDND_STOP_TRANSMISSION   = (12, )
+
+CMD_APP_CMD               = (55, 0, 0)
+ACMD_SD_SEND_OP_COND0     = (41, 0, 0)
+ACMD_SD_SEND_OP_COND4     = (41, 0x4000_0000, 0)
+
+class SDCardError(Exception): pass
+
+def init() -> bool:
+    """Probe and initialise a connection to a possible SDCard"""
+    global start_lba, num_lba, signature
+
+    ##print("probing...")
+    signature = None
+    low_speed()
+    card_version = None
+    for _ in range(2):
+        card_version = probe_card()
+        if card_version is not None: break
+
+    if card_version is None:
+        print("error(init): no sdcard found")
+        return False  # ERROR
+    ##print("card version:%d" % card_version)
+
+    if   card_version == 1: init_cardV1()
+    elif card_version == 2: init_cardV2()
+    else:
+        print("error(init): Unknown card version:%d" % card_version)
+        return False  # ERROR
+
+    ##print("get_csd...")
+    csd = get_csd()
+    if csd is None:
+        print("error(init): get_csd()")
+        return False  # ERROR
+
+    start_lba = 0
+    num_lba   = parse_num_blocks(csd)
+    #print(f"nblocks={nblocks:,} ({nblocks*512:,} bytes)")
+
+    set_block_length()  # always 512 on V2 card
+    high_speed()
+    signature = ticks_ms()  # time of successful mount
+    return True  # OK
+
+def eject() -> None:
+    """Invalidate any connection to a SDCard"""
+    global cdv, start_lba, num_lba, signature
+    cdv       = None
+    start_lba = None
+    num_lba   = None
+    signature = None
+
+def get_signature() -> int or None:
+    """Get a unique signature for this mount, None if not known"""
+    global signature
+    # This can be used to later detect card ejects
+    return signature
+
+def get_size_blocks() -> int or None:
+    """Get the size of this card in 512 byte LBA blocks"""
+    csd = get_csd()
+    if not csd:
+        print("error(get_size_bytes): can't get_csd()")
+        return None  # ERROR
+
+    return parse_num_blocks(csd)
+
+def get_size_bytes() -> int or None:
+    """Get the size of this card in bytes"""
+    s = get_size_blocks()
+    if s is None: return s
+    return s * 512
+
+# used by writeblocks()
+# def cmd_nodata(cmd) -> bool:
+#     """Send a command that has no data"""
+#     spi_cs.low()
+#     spi.read(1, cmd)
+#     spi.read(1, 0xFF)  # ignore stuff byte
+#     timeout_at = ticks_us() + TIMEOUT_CMD_US
+#     while ticks_us() < timeout_at:
+#         spi.readinto(buf1, 0xFF)
+#         if 0xFF == buf1[0]:  # or, check high bit??
+#             spi_cs.high()
+#             spi.read(1, 0xFF)
+#             return True  # OK
+#     spi_cs.high()
+#     spi.read(1, 0xFF)
+#     print("error: timeout in cmd_nodata")
+#     return False  # TIMEOUT
+
+# def time_fn(fn:callable) -> callable:
+#     def timeit(*args, **kwargs):
+#         start = ticks_us()
+#         res = fn(*args, **kwargs)
+#         end = ticks_us()
+#         diff = end - start
+#         print(diff)
+#         return res
+#     return timeit
+
+def cmd(cmdno:int, arg:int, crc:int, final_ff:int=0, release:bool=True) -> int or None:
+    """Create and send a command"""
+    spi_cs.low()
+
+    txbuf = cmdbuf[:6]
+    txbuf[0] = 0x40 | cmdno
+    txbuf[1] = arg >> 24
+    txbuf[2] = arg >> 16
+    txbuf[3] = arg >> 8
+    txbuf[4] = arg
+    txbuf[5] = crc
+    spi.write(txbuf)
+
+    # busy-wait for response bit7==0
+    timeout_at = ticks_us() + TIMEOUT_OF_CMD_US
+    while ticks_us() < timeout_at:
+        spi.readinto(buf1, 0xFF)
+        response = buf1[0]
+        if not (response & 0x80):
+            if final_ff != 0: spi.read(final_ff, 0xFF)
+            if release:
+                spi_cs.high()
+                spi.read(1, 0xFF)
+            return response
+
+    # timeout
+    spi_cs.high()
+    spi.read(1, 0xFF)
+    print("error: CMD%d timeout" % cmd)
+    return None  # NO_RESPONSE
+
+def write(token, buf) -> bool:
+    """Write a data block and check it was accepted"""
+    assert len(buf) == 512
+    spi_cs.low()
+
+    # send: start of block, data, checksum
+    spi.read(1, token)
+    spi.write(buf)
+    spi.read(2, 0xFF)  # skip checksum word
+
+    # check the response
+    spi.readinto(buf1, 0xFF)
+    response = buf1[0]
+    if response & 0x1F != DRT_ACCEPTED:
+        spi_cs.high()
+        spi.read(1, 0xFF)
+        print("error(write):wrong response, expect:05, got:%02X" % response)
+        return False  # ERROR
+
+    # wait for write to finish
+    timeout_at = ticks_ms() + TIMEOUT_WRITE_MS
+    while ticks_ms() < timeout_at:
+        spi.readinto(buf1, 0xFF)
+        if buf1[0] != 0:
+            spi_cs.high()
+            spi.read(1, 0xFF)
+            return True  # OK
+
+    print("error(write): timeout after %d ms" % TIMEOUT_WRITE_MS)
+    return False  # TIMEOUT
+
+def readinto(buf):
+    """Read a data block"""
+    spi_cs.low()
+
+    # read until start byte
+    while True:
+        spi.readinto(buf1, 0xFF)
+        if buf1[0] == 0xFE: break
+
+    # read data
+    spi.readinto(buf, 0xFF)
+
+    # skip checksum word
+    spi.read(2, 0xFF)
+
+    spi_cs.high()
+    spi.read(1, 0xFF)
+
+def probe_card() -> int or None:  # CARD_VERSION | UNKNOWN
+    """See if a card is present, what version is it?"""
+    # clock card at least 100 cycles with cs high
+    #NOTE: no idea why this is needed, is this to flush the cmd pipeline?
+    #there was no mention of this in the sdcard.org spec
+    #but the micropython driver does it.
+    spi.read(16, 0xFF)
+
+    for _ in range(5):
+        if cmd(*CMD_INIT) == R1_IDLE_STATE: break
+    else:
+        ##print("error(probe_card): no response from CMD_INIT")
+        return None  # NO SDCARD
+
+    r = cmd(*CMD_GET_CARD_VER)
+    if r == R1_IDLE_STATE:
+        return 2  # V2 CARD
+    elif r == R1_IDLE_STATE | R1_ILLEGAL_COMMAND:
+        return 1  # V1 CARD
+    else:
+        print("error(probe_card): unknown SD card version (rsp=%02X)" % r)
+        return 0xFF  # UNKNOWN SD CARD VER
+
+def init_cardV1() -> bool:
+    """Initialise a card known to be a V1 card"""
+    global cdv
+    for _ in range(INIT_RETRY_TIMES):
+        cmd(*CMD_APP_CMD)
+        if cmd(*ACMD_SD_SEND_OP_COND0) == 0:
+            ##print("V1, cdv=512")
+            cdv = 512
+            return True  # OK
+    print("error(init_cardV1): timeout V1")
+    return False  # TIMEOUT
+
+def init_cardV2() -> bool:
+    """Initialise a card known to be a V2 card"""
+    global cdv
+    for _ in range(INIT_RETRY_TIMES):
+        cmd(*CMD_READ_OCR_ND)
+        cmd(*CMD_APP_CMD)
+        if 0 == cmd(*ACMD_SD_SEND_OP_COND4):
+            cmd(*CMD_READ_OCR_ND)
+            ##print("V2, cdv=1")
+            cdv = 1
+            return True  # OK
+        sleep_ms(INIT_RETRY_DELAY_MS)
+    print("error(init_cardV2): timeout V2")
+    return False  # TIMEOUT
+
+def get_cid() -> bytes or None:
+    """Read the CID record"""
+    if 0 != cmd(*CMD_SEND_CID_DATA):
+        print("error(get_cid): no response")
+        return None
+    cid = bytearray(16)
+    readinto(cid)
+    return bytes(cid)  # immutable
+
+def get_csd() -> bytes or None:
+    """Read the CSD record"""
+    if 0 != cmd(*CMD_SEND_CSD_DATA):
+        print("error(get_csd): no response")
+        return None
+    csd = bytearray(16)
+    readinto(csd)
+
+    if csd[0] & 0xc0 != 0x40: #CSD_STRUCTURE b01 == CSD version 2.0
+        print("error(get_num_sectors): did not get a V2 CSD_STRUCTURE")
+        return None  # ERROR
+    return bytes(csd)  # immutable
+
+def parse_num_blocks(csd:bytes) -> int:
+    """Parse the C_SIZE field out as a number of 512 byte blocks on the card"""
+    # C_SIZE upper 6 always zero, so this is 16 bits
+    # capacity = (CSIZE+1) * 512KByte   i.e.: * 524288 = 0x8_0000 = 512KB
+    # actual CSD_SIZE_MULT always 512Kbyte in version 2 record
+    # CSD records are big-endian
+    CSIZE = ((csd[8] << 8 | csd[9]) + 1)  # multiply by  512KB
+    ##print("CSIZE:%d (%04X)" % (CSIZE, CSIZE))
+    ##nbytes = (CSIZE * 512 * 1024) / 512
+    return CSIZE * 1024
+
+def set_block_length() -> bool:
+    """Set the block transfer length for block reads and writes"""
+    if cmd(*CMD_SET_BLOCKLEN_512) != 0:
+        print("error(set_block_length): can't set block length")
+        return False  # FAILED
+    return True  # OK
+
+def high_speed():
+    """Move to high speed SPI, now card is initialised"""
+    spi.init(baudrate=SPEED_FAST_HZ, phase=0, polarity=0)
+
+def low_speed():
+    """Move to low speed SPI, for card probing"""
+    spi.init(baudrate=SPEED_SLOW_HZ, phase=0, polarity=0)
+
+def readblock(block_num:int, buf) -> bool:
+    """Read a whole logical block into provided buffer"""
+    assert len(buf) == 512, "readblock: wrong block size, want:512, got:%d" % len(buf)
+    if 0 != cmd(*CMDFN_READ_SINGLE_BLOCK(block_num)):
+        return False  # ERROR
+    # receive the data
+    readinto(buf)
+    return True  # OK
+
+# NOT YET TESTED
+# def readblocks(block_num:int, buf) -> bool:
+#     nblocks, rem = divmod(len(buf), 512)
+#     assert nblocks and not rem, "readblocks: invalid non zero remainder:%d" % rem
+#     if nblocks == 1:
+#         return readblock(block_num, buf)
+#     else:
+#         if 0 != cmd(*CMDFN_READ_MULTIPLE_BLOCK(block_num)):
+#             return False  # ERROR
+#         offset = 0
+#         mv = memoryview(buf)
+#         while nblocks:
+#             readinto(mv[offset : offset + 512])
+#             offset += 512
+#             nblocks -= 1
+#         return cmd_nodata(CMDND_STOP_TRANSMISSION)
+
+def writeblock(block_num:int, buf) -> bool:
+    """Write a whole logical block to the card"""
+    assert len(buf) % 512 == 0
+    response = cmd(*CMDFN_WRITE_BLOCK(block_num))
+    if response != 0:
+        print("error(writeblock): CMD_WRITE_BLOCK failed with %02X" % response)
+        return False  # ERROR
+
+    # send the data
+    return write(TOKEN_DATA, buf)
+
+#----- REGION - for a range of blocks on a device ------------------------------
+
+class Region:
+    def __init__(self, r_start:int=0, r_size:int or None=None):
+        assert r_start is not None
+        card_sig = get_signature()
+        if card_sig is None: raise SDCardError("sdcard not mounted")
+
+        card_blocks = get_size_blocks()
+        assert card_blocks is not None
+
+        # validate start
+        if r_start < 0 or r_start >= card_blocks:
+            raise ValueError("start out of range: got:%d max:%d" % (r_start, card_blocks-1))
+
+        max_size = card_blocks - r_start
+        if r_size is None: r_size = max_size
+
+        # validate num_blocks
+        if r_size > max_size:
+            raise ValueError("num_blocks out of range: got:%d max:%d" % (r_size, max_size))
+
+        # update state
+        self._start     = r_start
+        self._size      = r_size
+        self._signature = card_sig
+
+    def __repr__(self) -> str:
+        return "Region(r_start=%s, r_size=%s)" % (str(self._start), str(self._size))
+
+    def __len__(self) -> int:
+        """The total number of 512 byte blocks in this region"""
+        return self._size
+
+    def __getitem__(self, idx):
+        """Get a constricted subset of this existing region"""
+        # e.g. a partition inside a device, or a file inside a partition
+        if self._signature != get_signature(): raise SDCardError("card has been ejected")
+        if isinstance(idx, int):
+            # a single block
+            start = idx
+            size = 1
+        else:
+            # slice, a range of blocks within this region
+            start = idx.start
+            size  = idx.stop - idx.start
+
+        # validate
+        if start >= self._size or start < 0:
+            raise ValueError("start out of range: got:%d max:%d" % (start, self._size))
+        max_ofs = self._size - start
+        if size > max_ofs or size < 0:
+            raise ValueError("size out of range: got:%d max:%d" % (size, max_ofs))
+
+        return Region(self._start + start, size)
+
+    def readinto(self, offset, buf) -> bool:
+        if self._signature != get_signature(): raise SDCardError("card has been changed")
+        assert offset < self._size, "Invalid offset, got:%d max:%d" % (offset, self._size-1)
+        return readblock(self._start+offset, buf)
+
+    def write(self, offset, buf) -> bool:
+        if self._signature != get_signature(): raise SDCardError("card has been changed")
+        assert offset < self._size, "Invalid offset, got:%d max:%d" % (offset, self._size-1)
+        return writeblock(self._start+offset, buf)
+

--- a/src/sdtool.py
+++ b/src/sdtool.py
@@ -1,0 +1,316 @@
+# sdtool.py  28/02/2023  D.J.Whale - SDCard experimentor tool
+
+import sdcard
+from utime import ticks_us
+import urandom
+
+def hexbytes(buf) -> str:
+    """build a run of hex bytes into hexascii"""
+    result = []
+    for b in buf:
+        result.append("%02X" % b)
+    return " ".join(result)
+
+def asciibytes(buf) -> str:
+    """build a run of ascii characters"""
+    result = []
+    for b in buf:
+        if 32 <= b < 127: result.append(chr(b))
+        else:             result.append('.')
+    return "".join(result)
+
+def print_block(buf, binary:bool=True, ascii:bool=False, addr:int=0) -> None:
+    """Print a block, must be modulo 16 bytes in length"""
+    assert len(buf) % 16 == 0
+    mv = memoryview(buf)
+
+    def pb(mem, binary:bool=True, ascii:bool=False, addr:int=0):
+        for ofs in range(0, len(mem), 16):
+            print("%03X: " % (addr+ofs), end="")
+            data = mem[ofs:ofs+16]
+            if binary: print(hexbytes(data), end=" ")
+            if ascii:  print(asciibytes(data), end="")
+            print()
+
+    # A whole block is too big for the screen, so provide a MORE option
+    pb(mv[:256], binary=binary, ascii=ascii)
+    if not input("more?") in ("N", 'n'):
+        pb(mv[256:], binary=binary, ascii=ascii, addr=256)
+
+def read_modify_write_verify(lba:int, offset:int, value:int) -> bool:
+    """Read a LBA block, modify it, write it, read back and verify"""
+    buf = bytearray(512)
+
+    # read
+    if not sdcard.readblock(lba, buf):
+        print("error(read_write_verify): can't readblock(%d)#1" % lba)
+        return False  # ERROR
+
+    # modify
+    # U16LE
+    buf[offset]   = value & 0xFF
+    buf[offset+1] = (value >>8) & 0xFF
+
+    # write
+    if not sdcard.writeblock(lba, buf):
+        print("error(read_modify_write_verify): Can't writeblock(%d)" % lba)
+        return False  # ERROR
+
+    # readback
+    if not sdcard.readblock(lba, buf):
+        print("error(read_modify_write_verify): Can't readblock(%d)#2" % lba)
+        return False  # ERROR
+
+    # verify
+    value2 = buf[0] | (buf[1]<<8)  # U16LE
+    if value2 != value:
+        print("error(read_modify_write_verify): wrote(%04X) but read(%04X)" % (value, value2))
+        return False  # ERROR
+
+    return True  # OK
+
+def lltest():
+    """Test the basic operation of an SDCard"""
+    print("init...")
+    if not sdcard.init():
+        print("FAIL: can't init card")
+        return
+
+    print("signature set to:%s" % str(sdcard.get_signature()))
+
+    #----- CHECK SIZE
+    print("get_size_blocks...")
+    nblocks = sdcard.get_size_blocks()
+    nbytes = sdcard.get_size_bytes()
+    if nblocks is None:
+        print("FAIL: can't get_size")
+        return
+    print(f"blocks: {nblocks:,} bytes: {nbytes:,}")
+
+    #----- BLOCK READ AND DISPLAY
+    data_block = bytearray(512)
+
+    print("readblock...")
+    if not sdcard.readblock(0, data_block):
+        print("FAIL: readblock(0)")
+        return
+
+    print_block(data_block, ascii=True)
+
+    #---- ZAP BLOCK TO ALL ZEROS
+    print("zero_block...")
+    buf = bytearray(512)
+    if not sdcard.writeblock(0, buf):
+        print("FAIL: can't write block to zeros")
+        return
+
+    #---- READ/MODIFY/WRITE/VERIFY a block
+    print("test_block#1...")
+    if not read_modify_write_verify(0, 0, 0xDEAD):
+        print("FAIL: can't write/read/verify#1")
+        return
+
+    print("test_block#2...")
+    if not read_modify_write_verify(0, 0, 0x1234):
+        print("FAIL: can't write/read/verify#2")
+        return
+
+    #---- EJECT
+    sdcard.eject()
+    sig = sdcard.get_signature()
+    print("ejected, signature now:%s" % str(sig))
+    if sig is not None:
+        print("FAIL: signature still set, should be None")
+        return
+
+    print("PASS")
+
+def connect():
+    """Probe SPI and connect to the card"""
+    if not sdcard.init():
+        print("FAIL: no card found")
+    else:
+        print("card connected")
+
+def info():
+    cid = sdcard.get_cid()
+    print("CID:", hexbytes(cid), asciibytes(cid))
+    csd = sdcard.get_csd()
+    print("CSD:", hexbytes(csd))
+
+def dumpmbr():
+    """Dump block 0 of card (master boot record)"""
+
+    buf = memoryview(bytearray(512))
+    if not sdcard.readblock(0, buf):
+        print("FAIL: can't readblock(0)")
+
+    print_block(buf, ascii=True)
+
+def LE32(buf) -> int:
+    assert len(buf) >= 4, "got len:%d" % len(buf)
+    return buf[3] << 24 | buf[2] << 16 | buf[1] << 8 | buf[0]
+
+def LE24(buf) -> int:
+    assert len(buf) >= 3, "got len:%d" % len(buf)
+    return buf[2] << 16 | buf[1] << 8 | buf[0]
+
+# def BE32(buf) -> int:
+#     assert len(buf) >= 4, "got len:%d" % len(buf)
+#     return buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3]
+#
+# def BE24(buf) -> int:
+#     assert len(buf) >= 3, "got len:%d" % len(buf)
+#     return buf[0] << 16 | buf[1] << 8 | buf[2]
+
+def print_ptab_ent(buf):
+    """Print a single partition table record"""
+    assert len(buf) >= 16
+    # 00            status (or physical drive) bit7 set for active/bootable
+    # 01,02,03      CHS address of first absolute sector (FE FF FF for LBA)
+    # 04            type (https://www.win.tue.nl/~aeb/partitions/partition_types-1.html) 00=empty
+    # 05,06,07      CHS address of last absolute sector
+    # 08,09,0A,0B   LBA of first absolute sector
+    # 0C,0D,0E,0F   number of sectors in partition
+
+    status    = buf[0x00]
+    CHS_first = LE24(buf[0x01:0x03+1])
+    type      = buf[0x04]
+    CHS_last  = LE24(buf[0x05:0x07+1])
+    LBA_first = LE32(buf[0x08:0x0B+1])
+    nsectors  = LE32(buf[0x0C:0x0F+1])
+
+    print("f:%02X first:%06X ty:%02X last:%06X LBA:%08X ns:%08X" % (
+        status, CHS_first, type, CHS_last, LBA_first, nsectors
+    ))
+
+def build_regions() -> tuple: # of Region or None
+    """Build 4 regions for the MBR partition table"""
+    mbr_r = sdcard.Region(0, 1)
+    mbr = memoryview(bytearray(512))
+    mbr_r.readinto(0, mbr)
+
+    ptab = mbr[512-2-(16*4):-2]
+    ptab_ents = [ptab[ofs:ofs + 16] for ofs in range(0, 64, 16)]
+
+    partitions = [None, None, None, None]
+    for i in range(4):
+        ent = ptab_ents[i]
+        if ent[4] != 0x00:
+            partitions[i] = sdcard.Region(LE32(ent[0x08:0x0B+1]), LE32(ent[0x0C:0x0F+1]))
+
+    return tuple(partitions)  # immutable index table
+
+def dumppart():
+    """Display the partition table inside the MBR"""
+    mbr_r = sdcard.Region(0, 1)
+    mbr = memoryview(bytearray(512))
+    mbr_r.readinto(0, mbr)
+
+    ptab = mbr[512-2-(16*4):-2]
+    ptab_ents = [ptab[ofs:ofs + 16] for ofs in range(0, 64, 16)]
+
+    # raw dump of partition table
+    for i in range(4):
+        print("p%d:" % i, hexbytes(ptab_ents[i]))
+    print()
+
+    # formatted dump of partition table
+    partitions = [None, None, None, None]
+    for i in range(4):
+        ent = ptab_ents[i]
+        if ent[4] != 0x00:
+            print_ptab_ent(ent)
+            partitions[i] = sdcard.Region(LE32(ent[0x08:0x0B+1]), LE32(ent[0x0C:0x0F+1]))
+    print()
+
+    # Dump partition regions
+    for i in range(4):
+        if partitions[i] is None:
+            print("%d: unused" % i)
+        else:
+            print("%d: %s (%d bytes)" % (i, partitions[i], len(partitions[i])*512))
+
+def dumpblock(region: sdcard.Region, ofs: int) -> None:
+    """Display one block in a partition"""
+    buf = bytearray(512)
+    if not region.readinto(ofs, buf):
+        print("FAIL: can't read block")
+        return
+
+    print_block(buf, ascii=True)
+
+def eject():
+    """Eject the card"""
+    sdcard.eject()
+
+def write_speed_test(block_no:int):
+    """Measure time needed to write a single block"""
+    print("write-test with physical block_no:%d" % block_no)
+    saved = bytearray(512)
+    if not sdcard.readblock(block_no, saved):  # save it for later restore
+        print("can't read block:%d" % block_no)
+        return
+
+    buf = bytearray(512)
+    def speed_test():
+        # random buffer each time, to prevent card squashing the write
+        for i in range(len(buf)):
+            buf[i] = urandom.randint(0, 256)
+
+        start = ticks_us()
+        r = sdcard.writeblock(block_no, buf)
+        end = ticks_us()
+        diff = end - start
+        if not r:
+            print("can't write block:%d" % block_no)
+        return diff
+
+    minv = None
+    maxv = None
+    sumv = 0
+    COUNT = 16
+    for _ in range(COUNT):
+        write_time = speed_test()
+        if minv is None or write_time < minv: minv = write_time
+        if maxv is None or write_time > maxv: maxv = write_time
+        sumv += write_time
+
+    sdcard.writeblock(block_no, saved)  # restore what was there before
+
+    avg = int(sumv/COUNT)
+    print(f"count: {COUNT} avg: {avg:,} us")
+    print(f"min time: {minv:,} us")
+    print(f"max time: {maxv:,} us")
+
+def run():
+    while True:
+        try:
+            test_no = input("c:connect i:info m:dumpmbr p:dumppart b:dumpblk W:writetst E:eject? ")
+            if   test_no == "T": lltest()  # hidden option
+            elif test_no == "c": connect()
+            elif test_no == 'i': info()
+            elif test_no == "m": dumpmbr()
+            elif test_no == "p": dumppart()
+            elif test_no.startswith("b"):
+                try:
+                    _, pno, ofs = test_no.split(" ")
+                    parts = build_regions()
+                    pno = int(pno)
+                    ofs = int(ofs)
+                    part = parts[pno]
+                    if part is None:
+                        print("Partition p%d is undefined" % pno)
+                    else:
+                        dumpblock(part, ofs)
+                except ValueError:
+                    print("Invalid parameters, try b 0 1  (partition 0, block 1)")
+
+            elif test_no == "E": eject()
+            elif test_no == "W":
+                write_speed_test(4)  # block 4 is probably block 2 in partition 0
+        except sdcard.SDCardError as e:
+            print(e)
+
+print("sdtool - SD card experimenter tool")
+run()

--- a/src/test_leds.py
+++ b/src/test_leds.py
@@ -17,26 +17,21 @@ def test_pin(pin_no: int, name:str=None):
         p.low()
         sleep_ms(250)
 
+def flash(pin, name:str="", times:int=4, delay_ms:int=250):
+    for t in range(times):
+        print("%s ON" % name)
+        pin.on()
+        sleep_ms(delay_ms)
+        print("%s OFF" % name)
+        pin.off()
+        sleep_ms(delay_ms)
+
 def test():
     led1 = Pin(LED1_GPN, Pin.OUT)
     led2 = Pin(LED2_GPN, Pin.OUT)
 
-    print("LED1(20) ON")
-    led1.on()
-    sleep_ms(500)
-
-    print("LED1(20) FF")
-    led1.off()
-    sleep_ms(500)
-
-    print("LED2(21) ON")
-    led2.on()
-    sleep_ms(500)
-
-    print("LED2(21) FF")
-    led2.off()
-    sleep_ms(500)
-
+    flash(led1, "LED1(%d)" % LED1_GPN)
+    flash(led2, "LED2(%d)" % LED2_GPN)
 
 print("test_leds program:")
 print("test() - test that both LEDs work")

--- a/src/test_leds.py
+++ b/src/test_leds.py
@@ -1,0 +1,42 @@
+# test_leds.py  23/02/2023  D.J.Whale - test the two board LEDs
+
+from machine import Pin
+from utime import sleep_ms
+
+LED1_GPN = 20  # {GP20}/TX1/SDA0/DI0/PWM2A
+LED2_GPN = 21  # {GP21}/RX1/SCL0/CS0/PWM2B
+
+def test_pin(pin_no: int, name:str=None):
+    """Use this for individual pin verification"""
+    if name is None: name = "GP%d" % pin_no
+    print("test_pin:%s %d" % (name, pin_no))
+    p = Pin(pin_no, Pin.OUT)
+    for _ in range(8):
+        p.high()
+        sleep_ms(250)
+        p.low()
+        sleep_ms(250)
+
+def test():
+    led1 = Pin(LED1_GPN, Pin.OUT)
+    led2 = Pin(LED2_GPN, Pin.OUT)
+
+    print("LED1(20) ON")
+    led1.on()
+    sleep_ms(500)
+
+    print("LED1(20) FF")
+    led1.off()
+    sleep_ms(500)
+
+    print("LED2(21) ON")
+    led2.on()
+    sleep_ms(500)
+
+    print("LED2(21) FF")
+    led2.off()
+    sleep_ms(500)
+
+
+print("test_leds program:")
+print("test() - test that both LEDs work")

--- a/src/test_pins.py
+++ b/src/test_pins.py
@@ -1,0 +1,102 @@
+# test_pins.py  23/02/2023  D.J.Whale - test arbitrary GP pins
+
+from machine import Pin
+from utime import sleep_ms
+
+def flash(gp_no, name:str="", times:int=4, delay_ms:int=250):
+    p = Pin(gp_no, Pin.OUT)
+    try:
+        for t in range(times):
+            print("%s ON(%d)" % (name, gp_no))
+            p.on()
+            sleep_ms(delay_ms)
+            print("%s OFF(%d)" % (name, gp_no))
+            p.off()
+            sleep_ms(delay_ms)
+    finally:
+        p = Pin(gp_no, Pin.IN)
+
+
+#TODO input pins need a different test, as do analogs
+#where there are multiple modes, must ask user for mode of test
+#TODO: def test_di_pin(pin_no: int, name:str=None)
+#TODO: def test_ai_pin(pin_no: int, name:str=None)
+
+INPUT  = 1<<0
+OUTPUT = 1<<2
+ANALOG = 1<<2
+
+#NOTE: if you fill in the adjacent pins, it will prompt the user to make sure
+#that these adjacent pins are not affected when a specific pin is flashed
+
+PIN_TABLE = (                                   #TODO vvv fill these in
+    # NAME              MODE(S)                     ADJACENT     number
+    ("RADIO_G0",        OUTPUT,                     "0-adj"),    # 0
+    ("RADIO_CS",        OUTPUT,                     "1-adj"),    # 1
+    ("RADIO_SCK",       OUTPUT,                     "2-adj"),    # 2
+    ("RADIO_MOSI",      OUTPUT,                     "3-adj"),    # 3
+    ("RADIO_MISO",      INPUT,                      "4-adj"),    # 4
+    ("CAMERA_CS",       OUTPUT,                     "5-adj"),    # 5
+    ("RADIO_RES",       OUTPUT,                     "6-adj"),    # 6
+    ("RADIO_EN",        OUTPUT,                     "7-adj"),    # 7
+    ("CAMERA_SDA",      INPUT | OUTPUT,             "8-adj"),    # 8
+    ("CAMERA_SCL",      OUTPUT,                     "9-adj"),    # 9
+    ("SDCARD_SCK",      OUTPUT,                     "10-adj"),   # 10
+    ("SDCARD_MOSI",     OUTPUT,                     "11-adj"),   # 11
+    ("SDCARD_MISO",     INPUT,                      "12-adj"),   # 12
+    ("SDCARD_CS",       OUTPUT,                     "13-adj"),   # 13
+    ("SPI1_CS",         OUTPUT,                     "14-adj"),   # 14
+    ("SPI0_CS",         OUTPUT,                     "15-adj"),   # 15
+    ("MISC16",          INPUT | OUTPUT,             "16-adj"),   # 16
+    ("BUTTON",          INPUT,                      "17-adj"),   # 17
+    ("I2C1_SDA",        INPUT | OUTPUT,             "18-adj"),   # 18
+    ("I2C1_SCL",        OUTPUT,                     "19-adj"),   # 19
+    ("LED1",            OUTPUT,                     "20-adj"),   # 20
+    ("LED2",            OUTPUT,                     "21-adj"),   # 21
+    ("MISC22",          INPUT | OUTPUT,             "22-adj"),   # 22
+    None,                                                        # 23 UNUSED
+    None,                                                        # 24 UNUSED
+    None,                                                        # 25 UNUSED
+    ("MISC26",          INPUT | ANALOG | OUTPUT,    "26-adj"),   # 26
+    ("MISC27",          INPUT | ANALOG | OUTPUT,    "27-adj"),   # 27
+    ("MISC28",          INPUT | ANALOG | OUTPUT,    "28-adj"),   # 28
+)
+
+NAME = 0
+MODE = 1
+ADJACENT = 2
+
+def test():
+    gp_no = 20  # default is first LED
+    try:
+        while True:
+            rsp = input("GP number, or return to test(%d)?" % gp_no)
+            if rsp != "":
+                # change the gp_no
+                try:
+                    gp_no = int(rsp)
+                except ValueError:
+                    print("must enter a number")
+                    continue
+
+                if gp_no < 0 or gp_no >= len(PIN_TABLE) or PIN_TABLE[gp_no] is None:
+                    print("Invalid pin number")
+                    continue
+            # else: leave the gp_no unchanged, run test again
+
+            print("adjacent:", PIN_TABLE[gp_no][ADJACENT])
+            flash(gp_no, name=PIN_TABLE[gp_no][NAME])
+
+    except KeyboardInterrupt:
+        print("\nCTRL-C")  # finished
+
+def list():
+    for i in range(len(PIN_TABLE)):
+        p = PIN_TABLE[i]
+        if p is not None:
+            print(p[0], "GP%d" % i )  # name, gp_no
+
+print("test_pins program:")
+print("  list()        - list available pin map")
+print("  flash(4)      - flash GP4 a few times")
+print("  test()        - test all pins interactively")

--- a/src/test_sdcard_spi.py
+++ b/src/test_sdcard_spi.py
@@ -1,0 +1,101 @@
+# test_sd_spi.py  23/02/2023  D.J.Whale - test SD card on SPIn
+
+from machine import SPI, Pin
+from utime import sleep_ms, sleep_us
+
+SPEED_HZ = 100_000
+SPI_N    = 1
+GP_SCK   = 10  # output
+GP_MOSI  = 11  # output
+GP_MISO  = 12  # input
+GP_CS    = 13  # output
+
+# init SPI
+spi = SPI(SPI_N, baudrate=SPEED_HZ, polarity=0, phase=0, bits=8,
+          sck=Pin(GP_SCK), mosi=Pin(GP_MOSI), miso=Pin(GP_MISO))
+
+# chip select idles high when bus inactive
+spi_cs = Pin(GP_CS, Pin.OUT)
+spi_cs.high()  # deselected
+
+def test_pin(pin_no: int, name:str=None):
+    """Use this for individual pin verification"""
+    if name is None: name = "GP%d" % pin_no
+    print("test_pin:%s %d" % (name, pin_no))
+    p = Pin(pin_no, Pin.OUT)
+    for _ in range(8):
+        p.high()
+        sleep_ms(250)
+        p.low()
+        sleep_ms(250)
+
+def init_card() -> int or None:  # CARD_VERSION | UNKNOWN
+    R1_IDLE_STATE       = 1<<0
+    R1_ILLEGAL_COMMAND  = 1<<2
+    RETRY_TIMES         = 100
+    # cmd, arg, crc, [final_ff=0], [release=True]
+    CMD_INIT            = (0, 0, 0x95)
+    CMD_GET_CARD_VER    = (8, 0x01aa, 0x87, 4)
+
+    def cmd(cmd:int, arg:int, crc:int, final_ff:int=0, release:bool=True) -> int or None:
+        """Create and send a command"""
+        spi_cs.low()
+
+        txbuf = bytearray(6)
+        txbuf[0] = 0x40 | cmd
+        txbuf[1] = arg >> 24
+        txbuf[2] = arg >> 16
+        txbuf[3] = arg >> 8
+        txbuf[4] = arg
+        txbuf[5] = crc
+        spi.write(txbuf)
+
+        # busy-wait for response bit7==0
+        rxbuf = bytearray(1)
+        for _ in range(RETRY_TIMES):
+            spi.readinto(rxbuf, 0xFF)
+            response = rxbuf[0]
+            if not (response & 0x80):
+                for _ in range(final_ff):  #TODO: spi.read(final_ff, 0xFF)
+                    spi.read(1, 0xFF)
+                if release:
+                    spi_cs.high()
+                    spi.read(1, 0xFF)
+                return response
+
+        # timeout
+        spi_cs.high()
+        spi.read(1, 0xFF)
+        return None  # NO_RESPONSE
+
+    # clock card at least 100 cycles with cs high
+    for _ in range(16):  #TODO: spi.read(16, 0xFF)
+        spi.read(1, 0xFF)
+
+    # CMD0: init card; should return R1_IDLE_STATE (allow 5 attempts)
+    for _ in range(5):
+        if cmd(*CMD_INIT) == R1_IDLE_STATE:
+            break
+    else:
+        return None  # NO SDCARD
+
+    # CMD8: determine card version
+    r = cmd(*CMD_GET_CARD_VER)
+    if r == R1_IDLE_STATE:
+        return 2  # V2 CARD
+    elif r == R1_IDLE_STATE | R1_ILLEGAL_COMMAND:
+        return 1  # V1 CARD
+    else:
+        return 0xFF  # UNKNOWN SD CARD VER
+
+def test():
+    """Use this to test the sdcard responds"""
+    card_version = init_card()
+    if card_version is None: print("FAIL: card did not respond")
+    else:                    print("PASS: card version:", card_version)
+
+print("test_sd_spi program:")
+print("  test_pin(10)  - toggle-test a GP pin, any number allowed")
+print("  PINS: sck:10  mosi:11  miso:12  cs:13")
+print("  test()        - check if sdcard responds to read-version command")
+


### PR DESCRIPTION
I have added an sdcard.py and a sdtool.py, that allows direct access to raw blocks of an SDCard. This will form part of a bigger solution later to allow writes to the disk in a way that doesn't suffer FAT corruptions on power loss.

Also you might find the new test_ programs useful, they are pin mapped to your existing board. I haven't finished the test_pins yet, but the radio_spi and sdcard_spi testers work.